### PR TITLE
Add audio warmth controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ AETTS (Audio Extraction, Transcription, Translation and Synthesis) is a local pi
 - **Offline transcription** using pre‑downloaded Whisper models.
 - **Offline translation** (DE → EN) using a local HuggingFace model.
 - **Speech synthesis** with Kokoro TTS and several voices.
-- **Audio enhancement** filters (high/low pass, noise reduction, compressor, dialogue enhancement).
+- **Audio enhancement** filters (high/low pass, noise reduction, compressor, dialogue enhancement, bass/treble control and reverb for a warmer sound).
 
 ## Installation
 1. Install Python 3.11 (as noted in `Notes`).
@@ -54,7 +54,7 @@ Run Whisper on the prepared audio. Choose the model size and language; transcrip
 Translate the German transcript to English using the local translation model.
 
 ### Bonus: Audio Enhancement Toolbox
-Apply ffmpeg-based filters such as high/low pass, noise reduction, and compression. Multiple files can be processed and downloaded as a zip.
+Apply ffmpeg-based filters to clean up or warm the sound. Options now include bass/treble adjustment and a subtle reverb in addition to high/low pass, noise reduction and compression. Multiple files can be processed and downloaded as a zip.
 
 ### 4. Synthesize Speech
 Generate speech from your chosen text with Kokoro TTS. Pick a voice from `config.py` and adjust the speed if needed.

--- a/app.py
+++ b/app.py
@@ -141,6 +141,10 @@ with gr.Blocks() as demo:
             highpass_slider = gr.Slider(minimum=0, maximum=500, value=100, step=10, label="High-pass Filter (Hz)")
             lowpass_slider = gr.Slider(minimum=2000, maximum=8000, value=4000, step=100, label="Low-pass Filter (Hz)")
         with gr.Row():
+            bass_slider = gr.Slider(minimum=-10, maximum=10, value=3, step=1, label="Bass Gain (dB)")
+            treble_slider = gr.Slider(minimum=-10, maximum=10, value=-2, step=1, label="Treble Gain (dB)")
+        reverb_slider = gr.Slider(minimum=0.0, maximum=1.0, value=0.1, step=0.05, label="Reverb Amount")
+        with gr.Row():
             noise_reduce_checkbox = gr.Checkbox(label="Enable Noise Reduction (afftdn)", value=False)
             dialogue_enhance_checkbox = gr.Checkbox(label="Enable Dialogue Enhancement", value=False)
         compressor_checkbox = gr.Checkbox(label="Enable Dynamic Range Compressor", value=True)
@@ -189,9 +193,11 @@ with gr.Blocks() as demo:
     enhance_button.click(
         enhance_audio,
         inputs=[
-            enhancement_audio_input, ffmpeg_path_input, 
-            highpass_slider, lowpass_slider, compressor_checkbox,
-            noise_reduce_checkbox, dialogue_enhance_checkbox
+            enhancement_audio_input, ffmpeg_path_input,
+            highpass_slider, lowpass_slider,
+            compressor_checkbox,
+            noise_reduce_checkbox, dialogue_enhance_checkbox,
+            bass_slider, treble_slider, reverb_slider
         ],
         outputs=[enhanced_audio_output, enhanced_files_output]
     )

--- a/audio_enhancement.py
+++ b/audio_enhancement.py
@@ -4,7 +4,19 @@ import tempfile
 import zipfile
 import gradio as gr
 
-def enhance_audio(audio_files, ffmpeg_path, highpass_freq, lowpass_freq, use_compressor, use_noise_reduction, use_dialogue_enhance, progress=gr.Progress()):
+def enhance_audio(
+    audio_files,
+    ffmpeg_path,
+    highpass_freq,
+    lowpass_freq,
+    use_compressor,
+    use_noise_reduction,
+    use_dialogue_enhance,
+    bass_gain,
+    treble_gain,
+    reverb_amount,
+    progress=gr.Progress(),
+):
     """
     Enhances audio files using ffmpeg filters.
     """
@@ -30,6 +42,14 @@ def enhance_audio(audio_files, ffmpeg_path, highpass_freq, lowpass_freq, use_com
             filter_complex.append("dialoguenhance")
         if use_compressor:
             filter_complex.append("acompressor=threshold=0.1:ratio=9:attack=200:release=1000")
+        if bass_gain != 0:
+            filter_complex.append(f"bass=g={bass_gain}")
+        if treble_gain != 0:
+            filter_complex.append(f"treble=g={treble_gain}")
+        if reverb_amount > 0:
+            # a simple reverb using the aecho filter for a warmer feel
+            decays = f"{reverb_amount}|{reverb_amount/2}"
+            filter_complex.append(f"aecho=0.8:0.9:40|60:{decays}")
 
         cmd = [
             ffmpeg_path,


### PR DESCRIPTION
## Summary
- extend `enhance_audio` with bass, treble, and reverb parameters
- expose new controls in the UI
- document updated enhancement options

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68604a4ef170832ba7e9f393d151ddb4