### PR TITLE
Add placeholder video and animated step sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,9 +12,53 @@
         <button id="github-btn" data-url="https://github.com/your_username/AETTS">GitHub</button>
     </header>
 
+    <section id="video">
+        <img src="https://placehold.co/800x450?text=Video+Tutorial" alt="Video tutorial placeholder">
+    </section>
+
     <section id="hero">
         <img src="https://via.placeholder.com/800x400?text=Hero+Image" alt="Hero placeholder">
         <p>Audio extraction, transcription, translation and synthesis in one lean toolkit.</p>
+    </section>
+
+    <section class="step">
+        <div class="content">
+            <h3>1. Extract Audio</h3>
+            <p>Grab audio from video files with a single command.</p>
+        </div>
+        <img src="https://placehold.co/400x300?text=Step+1" alt="Step 1 placeholder">
+    </section>
+
+    <section class="step">
+        <div class="content">
+            <h3>2. Remove Silence</h3>
+            <p>Automatically remove long pauses and split the audio into chunks.</p>
+        </div>
+        <img src="https://placehold.co/400x300?text=Step+2" alt="Step 2 placeholder">
+    </section>
+
+    <section class="step">
+        <div class="content">
+            <h3>3. Transcribe</h3>
+            <p>Run Whisper locally to transcribe the audio.</p>
+        </div>
+        <img src="https://placehold.co/400x300?text=Step+3" alt="Step 3 placeholder">
+    </section>
+
+    <section class="step">
+        <div class="content">
+            <h3>4. Translate</h3>
+            <p>Convert German transcripts into English.</p>
+        </div>
+        <img src="https://placehold.co/400x300?text=Step+4" alt="Step 4 placeholder">
+    </section>
+
+    <section class="step">
+        <div class="content">
+            <h3>5. Synthesize Speech</h3>
+            <p>Generate lifelike speech with Kokoro TTS.</p>
+        </div>
+        <img src="https://placehold.co/400x300?text=Step+5" alt="Step 5 placeholder">
     </section>
 
     <section id="features">

--- a/script.js
+++ b/script.js
@@ -1,3 +1,14 @@
 document.getElementById('github-btn').addEventListener('click', function() {
     window.open(this.dataset.url, '_blank');
 });
+
+const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+        if (entry.isIntersecting) {
+            entry.target.classList.add('visible');
+            observer.unobserve(entry.target);
+        }
+    });
+}, { threshold: 0.1 });
+
+document.querySelectorAll('.step').forEach(step => observer.observe(step));

--- a/style.css
+++ b/style.css
@@ -28,6 +28,11 @@ header {
     height: auto;
 }
 
+#video img {
+    width: 100%;
+    height: auto;
+}
+
 section {
     padding: 2rem 1rem;
 }
@@ -39,4 +44,35 @@ ul {
 
 li {
     margin: 0.5rem 0;
+}
+
+.step {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 2rem;
+    text-align: left;
+    opacity: 0;
+    transform: translateY(50px);
+    transition: all 0.6s ease-out;
+}
+
+.step:nth-child(even) {
+    flex-direction: row-reverse;
+}
+
+.step img {
+    width: 400px;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
+.step.visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+#features {
+    background: #f7f7f7;
 }


### PR DESCRIPTION
## Summary
- embed a placeholder video section below the header
- add five step sections with alternating layout and images
- style new sections and implement fade-in animation on scroll

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_68604bc7ae90832b9d1c5b2f1f0b7b6c