### PR TITLE
Stream translation chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Extract audio from a video or upload an audio file. You can remove silence and o
 Run Whisper on the prepared audio. Choose the model size and language; transcripts are saved in `transcripts/`.
 
 ### 3. Translate Text
-Translate the German transcript to English using the local translation model.
+Translate the German transcript to English using the local translation model. Large blocks of text are translated sentence by sentence and streamed back to the interface.
 
 ### Bonus: Audio Enhancement Toolbox
 Apply ffmpeg-based filters to clean up or warm the sound. Options now include bass/treble adjustment and a subtle reverb in addition to high/low pass, noise reduction and compression. Multiple files can be processed and downloaded as a zip.

--- a/translation_logic.py
+++ b/translation_logic.py
@@ -2,6 +2,7 @@
 import gradio as gr
 import functools
 import os
+import re
 from transformers import pipeline
 from config import AppConfig, CUDA_AVAILABLE
 
@@ -34,29 +35,42 @@ def load_translator(device):
     return pipeline("translation_de_to_en", model=local_model_path, device=hf_device)
 
 
-def step5_translate_text(original_text, use_gpu, progress=gr.Progress()):
-    """
-    Translates text using the locally-loaded model.
-    """
-    if not original_text.strip(): raise gr.Error("No text to translate.")
+def _split_text(text, sentences_per_chunk=1):
+    """Split text into chunks of a given number of sentences."""
+    sentences = re.split(r"(?<=[.!?])\s+", text.strip())
+    chunks = []
+    for i in range(0, len(sentences), sentences_per_chunk):
+        chunk = " ".join(sentences[i:i + sentences_per_chunk]).strip()
+        if chunk:
+            chunks.append(chunk)
+    return chunks
 
-    # Determine device for the pipeline
+
+def step5_translate_text(original_text, use_gpu, progress=gr.Progress()):
+    """Translate text in smaller chunks and stream the result."""
+    if not original_text.strip():
+        raise gr.Error("No text to translate.")
+
     device = "cpu"
     if use_gpu:
         if CUDA_AVAILABLE:
             device = "cuda"
-        elif torch.backends.mps.is_available(): # Check for MPS here as well
+        elif torch.backends.mps.is_available():
             device = "mps"
 
     progress(0, desc=f"Loading translator on {device}...")
     try:
         translator = load_translator(device)
-        progress(0.5, desc="Translating DE -> EN...")
-        # The pipeline handles batching, but for a single text box, this is fine.
-        result = translator(original_text, max_length=512) # Added max_length for safety
-        translated_text = result[0]['translation_text']
-        progress(1, "Translation Complete!")
-        return translated_text
+        chunks = _split_text(original_text, sentences_per_chunk=1)
+        translated_chunks = []
+        for i, chunk in enumerate(chunks):
+            progress((i / max(len(chunks), 1)) * 0.9 + 0.05,
+                     desc=f"Translating chunk {i + 1}/{len(chunks)}...")
+            result = translator(chunk, max_length=512)
+            translated_chunk = result[0]["translation_text"]
+            translated_chunks.append(translated_chunk)
+            yield " ".join(translated_chunks)
+        progress(1, desc="Translation Complete!")
     except Exception as e:
         raise gr.Error(f"Translation failed: {e}")
 


### PR DESCRIPTION
## Summary
- split long text into sentence-sized chunks for translation
- stream partial translations back to the UI
- document streaming translation in README

## Testing
- `python -m py_compile translation_logic.py`

------
https://chatgpt.com/codex/tasks/task_b_68605b42aa6c832b93f091d5da292756